### PR TITLE
split `const`/`sym` asm tests into their own file

### DIFF
--- a/tests/ui/asm/aarch64/type-check-2.rs
+++ b/tests/ui/asm/aarch64/type-check-2.rs
@@ -15,15 +15,6 @@ fn main() {
     unsafe {
         // Inputs must be initialized
 
-        // Sym operands must point to a function or static
-
-        const C: i32 = 0;
-        static S: i32 = 0;
-        asm!("{}", sym S);
-        asm!("{}", sym main);
-        asm!("{}", sym C);
-        //~^ ERROR invalid `sym` operand
-
         // Register operands must be Copy
 
         asm!("{:v}", in(vreg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
@@ -65,12 +56,3 @@ fn main() {
         asm!("{}", in(reg) u);
     }
 }
-
-// Sym operands must point to a function or static
-
-const C: i32 = 0;
-static S: i32 = 0;
-global_asm!("{}", sym S);
-global_asm!("{}", sym main);
-global_asm!("{}", sym C);
-//~^ ERROR invalid `sym` operand

--- a/tests/ui/asm/aarch64/type-check-2.stderr
+++ b/tests/ui/asm/aarch64/type-check-2.stderr
@@ -1,29 +1,13 @@
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:75:19
-   |
-LL | global_asm!("{}", sym C);
-   |                   ^^^^^ is an `i32`
-   |
-   = help: `sym` operands must refer to either a function or a static
-
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:24:20
-   |
-LL |         asm!("{}", sym C);
-   |                    ^^^^^ is an `i32`
-   |
-   = help: `sym` operands must refer to either a function or a static
-
 error: arguments for inline assembly must be copyable
-  --> $DIR/type-check-2.rs:29:31
+  --> $DIR/type-check-2.rs:20:31
    |
 LL |         asm!("{:v}", in(vreg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 
-error: cannot use value of type `{closure@$DIR/type-check-2.rs:41:28: 41:36}` for inline assembly
-  --> $DIR/type-check-2.rs:41:28
+error: cannot use value of type `{closure@$DIR/type-check-2.rs:32:28: 32:36}` for inline assembly
+  --> $DIR/type-check-2.rs:32:28
    |
 LL |         asm!("{}", in(reg) |x: i32| x);
    |                            ^^^^^^^^^^
@@ -31,7 +15,7 @@ LL |         asm!("{}", in(reg) |x: i32| x);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `Vec<i32>` for inline assembly
-  --> $DIR/type-check-2.rs:43:28
+  --> $DIR/type-check-2.rs:34:28
    |
 LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
@@ -40,7 +24,7 @@ LL |         asm!("{}", in(reg) vec![0]);
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
-  --> $DIR/type-check-2.rs:45:28
+  --> $DIR/type-check-2.rs:36:28
    |
 LL |         asm!("{}", in(reg) (1, 2, 3));
    |                            ^^^^^^^^^
@@ -48,7 +32,7 @@ LL |         asm!("{}", in(reg) (1, 2, 3));
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `[i32; 3]` for inline assembly
-  --> $DIR/type-check-2.rs:47:28
+  --> $DIR/type-check-2.rs:38:28
    |
 LL |         asm!("{}", in(reg) [1, 2, 3]);
    |                            ^^^^^^^^^
@@ -56,7 +40,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `fn() {main}` for inline assembly
-  --> $DIR/type-check-2.rs:55:31
+  --> $DIR/type-check-2.rs:46:31
    |
 LL |         asm!("{}", inout(reg) f);
    |                               ^
@@ -64,12 +48,12 @@ LL |         asm!("{}", inout(reg) f);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `&mut i32` for inline assembly
-  --> $DIR/type-check-2.rs:58:31
+  --> $DIR/type-check-2.rs:49:31
    |
 LL |         asm!("{}", inout(reg) r);
    |                               ^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/asm/invalid-const-operand.rs
+++ b/tests/ui/asm/invalid-const-operand.rs
@@ -1,0 +1,51 @@
+//@ needs-asm-support
+//@ ignore-nvptx64
+//@ ignore-spirv
+
+#![feature(asm_const)]
+
+use std::arch::{asm, global_asm};
+
+// Const operands must be integers and must be constants.
+
+global_asm!("{}", const 0);
+global_asm!("{}", const 0i32);
+global_asm!("{}", const 0i128);
+global_asm!("{}", const 0f32);
+//~^ ERROR invalid type for `const` operand
+global_asm!("{}", const 0 as *mut u8);
+//~^ ERROR invalid type for `const` operand
+
+fn main() {
+    unsafe {
+        // Const operands must be integers and must be constants.
+
+        asm!("{}", const 0);
+        asm!("{}", const 0i32);
+        asm!("{}", const 0i128);
+        asm!("{}", const 0f32);
+        //~^ ERROR invalid type for `const` operand
+        asm!("{}", const 0 as *mut u8);
+        //~^ ERROR invalid type for `const` operand
+        asm!("{}", const &0);
+        //~^ ERROR invalid type for `const` operand
+
+        // Constants must be... constant
+
+        let x = 0;
+        const fn const_foo(x: i32) -> i32 {
+            x
+        }
+        const fn const_bar<T>(x: T) -> T {
+            x
+        }
+        asm!("{}", const x);
+        //~^ ERROR attempt to use a non-constant value in a constant
+        asm!("{}", const const_foo(0));
+        asm!("{}", const const_foo(x));
+        //~^ ERROR attempt to use a non-constant value in a constant
+        asm!("{}", const const_bar(0));
+        asm!("{}", const const_bar(x));
+        //~^ ERROR attempt to use a non-constant value in a constant
+    }
+}

--- a/tests/ui/asm/invalid-const-operand.stderr
+++ b/tests/ui/asm/invalid-const-operand.stderr
@@ -1,0 +1,86 @@
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/invalid-const-operand.rs:42:26
+   |
+LL |         asm!("{}", const x);
+   |                          ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/invalid-const-operand.rs:45:36
+   |
+LL |         asm!("{}", const const_foo(x));
+   |                                    ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
+
+error[E0435]: attempt to use a non-constant value in a constant
+  --> $DIR/invalid-const-operand.rs:48:36
+   |
+LL |         asm!("{}", const const_bar(x));
+   |                                    ^ non-constant value
+   |
+help: consider using `const` instead of `let`
+   |
+LL |         const x: /* Type */ = 0;
+   |         ~~~~~  ++++++++++++
+
+error: invalid type for `const` operand
+  --> $DIR/invalid-const-operand.rs:14:19
+   |
+LL | global_asm!("{}", const 0f32);
+   |                   ^^^^^^----
+   |                         |
+   |                         is an `f32`
+   |
+   = help: `const` operands must be of an integer type
+
+error: invalid type for `const` operand
+  --> $DIR/invalid-const-operand.rs:16:19
+   |
+LL | global_asm!("{}", const 0 as *mut u8);
+   |                   ^^^^^^------------
+   |                         |
+   |                         is a `*mut u8`
+   |
+   = help: `const` operands must be of an integer type
+
+error: invalid type for `const` operand
+  --> $DIR/invalid-const-operand.rs:26:20
+   |
+LL |         asm!("{}", const 0f32);
+   |                    ^^^^^^----
+   |                          |
+   |                          is an `f32`
+   |
+   = help: `const` operands must be of an integer type
+
+error: invalid type for `const` operand
+  --> $DIR/invalid-const-operand.rs:28:20
+   |
+LL |         asm!("{}", const 0 as *mut u8);
+   |                    ^^^^^^------------
+   |                          |
+   |                          is a `*mut u8`
+   |
+   = help: `const` operands must be of an integer type
+
+error: invalid type for `const` operand
+  --> $DIR/invalid-const-operand.rs:30:20
+   |
+LL |         asm!("{}", const &0);
+   |                    ^^^^^^--
+   |                          |
+   |                          is a `&i32`
+   |
+   = help: `const` operands must be of an integer type
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0435`.

--- a/tests/ui/asm/invalid-sym-operand.rs
+++ b/tests/ui/asm/invalid-sym-operand.rs
@@ -1,0 +1,30 @@
+use std::arch::{asm, global_asm};
+
+fn main() {
+    unsafe {
+        // Sym operands must point to a function or static
+
+        let x: u64 = 0;
+        const C: i32 = 0;
+        static S: i32 = 0;
+        asm!("{}", sym S);
+        asm!("{}", sym main);
+        asm!("{}", sym C);
+        //~^ ERROR invalid `sym` operand
+        asm!("{}", sym x);
+        //~^ ERROR invalid `sym` operand
+    }
+}
+
+unsafe fn generic<T>() {
+    asm!("{}", sym generic::<T>);
+}
+
+// Sym operands must point to a function or static
+
+const C: i32 = 0;
+static S: i32 = 0;
+global_asm!("{}", sym S);
+global_asm!("{}", sym main);
+global_asm!("{}", sym C);
+//~^ ERROR invalid `sym` operand

--- a/tests/ui/asm/invalid-sym-operand.rs
+++ b/tests/ui/asm/invalid-sym-operand.rs
@@ -1,5 +1,14 @@
 use std::arch::{asm, global_asm};
 
+// Sym operands must point to a function or static
+
+const C: i32 = 0;
+static S: i32 = 0;
+global_asm!("{}", sym S);
+global_asm!("{}", sym main);
+global_asm!("{}", sym C);
+//~^ ERROR invalid `sym` operand
+
 fn main() {
     unsafe {
         // Sym operands must point to a function or static
@@ -19,12 +28,3 @@ fn main() {
 unsafe fn generic<T>() {
     asm!("{}", sym generic::<T>);
 }
-
-// Sym operands must point to a function or static
-
-const C: i32 = 0;
-static S: i32 = 0;
-global_asm!("{}", sym S);
-global_asm!("{}", sym main);
-global_asm!("{}", sym C);
-//~^ ERROR invalid `sym` operand

--- a/tests/ui/asm/invalid-sym-operand.stderr
+++ b/tests/ui/asm/invalid-sym-operand.stderr
@@ -1,5 +1,5 @@
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:14:24
+  --> $DIR/invalid-sym-operand.rs:23:24
    |
 LL |         asm!("{}", sym x);
    |                        ^ is a local variable
@@ -7,18 +7,18 @@ LL |         asm!("{}", sym x);
    = help: `sym` operands must refer to either a function or a static
 
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:12:20
+  --> $DIR/invalid-sym-operand.rs:9:19
    |
-LL |         asm!("{}", sym C);
-   |                    ^^^^^ is an `i32`
+LL | global_asm!("{}", sym C);
+   |                   ^^^^^ is an `i32`
    |
    = help: `sym` operands must refer to either a function or a static
 
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:29:19
+  --> $DIR/invalid-sym-operand.rs:21:20
    |
-LL | global_asm!("{}", sym C);
-   |                   ^^^^^ is an `i32`
+LL |         asm!("{}", sym C);
+   |                    ^^^^^ is an `i32`
    |
    = help: `sym` operands must refer to either a function or a static
 

--- a/tests/ui/asm/invalid-sym-operand.stderr
+++ b/tests/ui/asm/invalid-sym-operand.stderr
@@ -1,0 +1,26 @@
+error: invalid `sym` operand
+  --> $DIR/invalid-sym-operand.rs:14:24
+   |
+LL |         asm!("{}", sym x);
+   |                        ^ is a local variable
+   |
+   = help: `sym` operands must refer to either a function or a static
+
+error: invalid `sym` operand
+  --> $DIR/invalid-sym-operand.rs:12:20
+   |
+LL |         asm!("{}", sym C);
+   |                    ^^^^^ is an `i32`
+   |
+   = help: `sym` operands must refer to either a function or a static
+
+error: invalid `sym` operand
+  --> $DIR/invalid-sym-operand.rs:29:19
+   |
+LL | global_asm!("{}", sym C);
+   |                   ^^^^^ is an `i32`
+   |
+   = help: `sym` operands must refer to either a function or a static
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/asm/type-check-1.rs
+++ b/tests/ui/asm/type-check-1.rs
@@ -28,46 +28,5 @@ fn main() {
         asm!("{}", inout(reg) v[..]);
         //~^ ERROR the size for values of type `[u64]` cannot be known at compilation time
         //~| ERROR cannot use value of type `[u64]` for inline assembly
-
-        // Constants must be... constant
-
-        let x = 0;
-        const fn const_foo(x: i32) -> i32 {
-            x
-        }
-        const fn const_bar<T>(x: T) -> T {
-            x
-        }
-        asm!("{}", const x);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("{}", const const_foo(0));
-        asm!("{}", const const_foo(x));
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("{}", const const_bar(0));
-        asm!("{}", const const_bar(x));
-        //~^ ERROR attempt to use a non-constant value in a constant
-
-        // Const operands must be integers and must be constants.
-
-        asm!("{}", const 0);
-        asm!("{}", const 0i32);
-        asm!("{}", const 0i128);
-        asm!("{}", const 0f32);
-        //~^ ERROR invalid type for `const` operand
-        asm!("{}", const 0 as *mut u8);
-        //~^ ERROR invalid type for `const` operand
-
-        asm!("{}", const &0);
-        //~^ ERROR invalid type for `const` operand
     }
 }
-
-// Const operands must be integers and must be constants.
-
-global_asm!("{}", const 0);
-global_asm!("{}", const 0i32);
-global_asm!("{}", const 0i128);
-global_asm!("{}", const 0f32);
-//~^ ERROR invalid type for `const` operand
-global_asm!("{}", const 0 as *mut u8);
-//~^ ERROR invalid type for `const` operand

--- a/tests/ui/asm/type-check-1.rs
+++ b/tests/ui/asm/type-check-1.rs
@@ -46,8 +46,6 @@ fn main() {
         asm!("{}", const const_bar(0));
         asm!("{}", const const_bar(x));
         //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("{}", sym x);
-        //~^ ERROR invalid `sym` operand
 
         // Const operands must be integers and must be constants.
 
@@ -62,10 +60,6 @@ fn main() {
         asm!("{}", const &0);
         //~^ ERROR invalid type for `const` operand
     }
-}
-
-unsafe fn generic<T>() {
-    asm!("{}", sym generic::<T>);
 }
 
 // Const operands must be integers and must be constants.

--- a/tests/ui/asm/type-check-1.stderr
+++ b/tests/ui/asm/type-check-1.stderr
@@ -31,14 +31,6 @@ help: consider using `const` instead of `let`
 LL |         const x: /* Type */ = 0;
    |         ~~~~~  ++++++++++++
 
-error: invalid `sym` operand
-  --> $DIR/type-check-1.rs:49:24
-   |
-LL |         asm!("{}", sym x);
-   |                        ^ is a local variable
-   |
-   = help: `sym` operands must refer to either a function or a static
-
 error: invalid asm output
   --> $DIR/type-check-1.rs:14:29
    |
@@ -103,7 +95,7 @@ LL |         asm!("{}", inout(reg) v[..]);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:57:20
+  --> $DIR/type-check-1.rs:55:20
    |
 LL |         asm!("{}", const 0f32);
    |                    ^^^^^^----
@@ -113,7 +105,7 @@ LL |         asm!("{}", const 0f32);
    = help: `const` operands must be of an integer type
 
 error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:59:20
+  --> $DIR/type-check-1.rs:57:20
    |
 LL |         asm!("{}", const 0 as *mut u8);
    |                    ^^^^^^------------
@@ -123,7 +115,7 @@ LL |         asm!("{}", const 0 as *mut u8);
    = help: `const` operands must be of an integer type
 
 error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:62:20
+  --> $DIR/type-check-1.rs:60:20
    |
 LL |         asm!("{}", const &0);
    |                    ^^^^^^--
@@ -133,7 +125,7 @@ LL |         asm!("{}", const &0);
    = help: `const` operands must be of an integer type
 
 error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:76:19
+  --> $DIR/type-check-1.rs:70:19
    |
 LL | global_asm!("{}", const 0f32);
    |                   ^^^^^^----
@@ -143,7 +135,7 @@ LL | global_asm!("{}", const 0f32);
    = help: `const` operands must be of an integer type
 
 error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:78:19
+  --> $DIR/type-check-1.rs:72:19
    |
 LL | global_asm!("{}", const 0 as *mut u8);
    |                   ^^^^^^------------
@@ -152,7 +144,7 @@ LL | global_asm!("{}", const 0 as *mut u8);
    |
    = help: `const` operands must be of an integer type
 
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0277, E0435.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/asm/type-check-1.stderr
+++ b/tests/ui/asm/type-check-1.stderr
@@ -1,36 +1,3 @@
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/type-check-1.rs:41:26
-   |
-LL |         asm!("{}", const x);
-   |                          ^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL |         const x: /* Type */ = 0;
-   |         ~~~~~  ++++++++++++
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/type-check-1.rs:44:36
-   |
-LL |         asm!("{}", const const_foo(x));
-   |                                    ^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL |         const x: /* Type */ = 0;
-   |         ~~~~~  ++++++++++++
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/type-check-1.rs:47:36
-   |
-LL |         asm!("{}", const const_bar(x));
-   |                                    ^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL |         const x: /* Type */ = 0;
-   |         ~~~~~  ++++++++++++
-
 error: invalid asm output
   --> $DIR/type-check-1.rs:14:29
    |
@@ -94,57 +61,6 @@ LL |         asm!("{}", inout(reg) v[..]);
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
-error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:55:20
-   |
-LL |         asm!("{}", const 0f32);
-   |                    ^^^^^^----
-   |                          |
-   |                          is an `f32`
-   |
-   = help: `const` operands must be of an integer type
+error: aborting due to 8 previous errors
 
-error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:57:20
-   |
-LL |         asm!("{}", const 0 as *mut u8);
-   |                    ^^^^^^------------
-   |                          |
-   |                          is a `*mut u8`
-   |
-   = help: `const` operands must be of an integer type
-
-error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:60:20
-   |
-LL |         asm!("{}", const &0);
-   |                    ^^^^^^--
-   |                          |
-   |                          is a `&i32`
-   |
-   = help: `const` operands must be of an integer type
-
-error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:70:19
-   |
-LL | global_asm!("{}", const 0f32);
-   |                   ^^^^^^----
-   |                         |
-   |                         is an `f32`
-   |
-   = help: `const` operands must be of an integer type
-
-error: invalid type for `const` operand
-  --> $DIR/type-check-1.rs:72:19
-   |
-LL | global_asm!("{}", const 0 as *mut u8);
-   |                   ^^^^^^------------
-   |                         |
-   |                         is a `*mut u8`
-   |
-   = help: `const` operands must be of an integer type
-
-error: aborting due to 16 previous errors
-
-Some errors have detailed explanations: E0277, E0435.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -27,17 +27,6 @@ fn main() {
         asm!("{}", out(reg) v[0]);
         asm!("{}", inout(reg) v[0]);
 
-        // Sym operands must point to a function or static
-
-        const C: i32 = 0;
-        static S: i32 = 0;
-        asm!("{}", sym S);
-        asm!("{}", sym main);
-        asm!("{}", sym C);
-        //~^ ERROR invalid `sym` operand
-        asm!("{}", sym x);
-        //~^ ERROR invalid `sym` operand
-
         // Register operands must be Copy
 
         asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
@@ -79,12 +68,3 @@ fn main() {
         asm!("{}", in(reg) u);
     }
 }
-
-// Sym operands must point to a function or static
-
-const C: i32 = 0;
-static S: i32 = 0;
-global_asm!("{}", sym S);
-global_asm!("{}", sym main);
-global_asm!("{}", sym C);
-//~^ ERROR invalid `sym` operand

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -1,21 +1,13 @@
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:38:24
-   |
-LL |         asm!("{}", sym x);
-   |                        ^ is a local variable
-   |
-   = help: `sym` operands must refer to either a function or a static
-
 error: arguments for inline assembly must be copyable
-  --> $DIR/type-check-2.rs:43:32
+  --> $DIR/type-check-2.rs:32:32
    |
 LL |         asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 
-error: cannot use value of type `{closure@$DIR/type-check-2.rs:55:28: 55:36}` for inline assembly
-  --> $DIR/type-check-2.rs:55:28
+error: cannot use value of type `{closure@$DIR/type-check-2.rs:44:28: 44:36}` for inline assembly
+  --> $DIR/type-check-2.rs:44:28
    |
 LL |         asm!("{}", in(reg) |x: i32| x);
    |                            ^^^^^^^^^^
@@ -23,7 +15,7 @@ LL |         asm!("{}", in(reg) |x: i32| x);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `Vec<i32>` for inline assembly
-  --> $DIR/type-check-2.rs:57:28
+  --> $DIR/type-check-2.rs:46:28
    |
 LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
@@ -32,7 +24,7 @@ LL |         asm!("{}", in(reg) vec![0]);
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
-  --> $DIR/type-check-2.rs:59:28
+  --> $DIR/type-check-2.rs:48:28
    |
 LL |         asm!("{}", in(reg) (1, 2, 3));
    |                            ^^^^^^^^^
@@ -40,7 +32,7 @@ LL |         asm!("{}", in(reg) (1, 2, 3));
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `[i32; 3]` for inline assembly
-  --> $DIR/type-check-2.rs:61:28
+  --> $DIR/type-check-2.rs:50:28
    |
 LL |         asm!("{}", in(reg) [1, 2, 3]);
    |                            ^^^^^^^^^
@@ -48,7 +40,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `fn() {main}` for inline assembly
-  --> $DIR/type-check-2.rs:69:31
+  --> $DIR/type-check-2.rs:58:31
    |
 LL |         asm!("{}", inout(reg) f);
    |                               ^
@@ -56,20 +48,12 @@ LL |         asm!("{}", inout(reg) f);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `&mut i32` for inline assembly
-  --> $DIR/type-check-2.rs:72:31
+  --> $DIR/type-check-2.rs:61:31
    |
 LL |         asm!("{}", inout(reg) r);
    |                               ^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:36:20
-   |
-LL |         asm!("{}", sym C);
-   |                    ^^^^^ is an `i32`
-   |
-   = help: `sym` operands must refer to either a function or a static
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/type-check-2.rs:15:28
@@ -113,15 +97,7 @@ help: consider changing this to be mutable
 LL |         let mut v: Vec<u64> = vec![0, 1, 2];
    |             +++
 
-error: invalid `sym` operand
-  --> $DIR/type-check-2.rs:89:19
-   |
-LL | global_asm!("{}", sym C);
-   |                   ^^^^^ is an `i32`
-   |
-   = help: `sym` operands must refer to either a function or a static
-
-error: aborting due to 13 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0381, E0596.
 For more information about an error, try `rustc --explain E0381`.


### PR DESCRIPTION
this fixes the error ordering problem we're running into in https://github.com/rust-lang/rust/pull/125558. What makes this work is that `global_asm!` now occurs earlier in the file than `asm!`. I've verified in https://github.com/rust-lang/rust/pull/128505 that this passes CI