### PR TITLE
add `needs-asm-support` to invalid-sym-operand

### DIFF
--- a/tests/ui/asm/invalid-sym-operand.rs
+++ b/tests/ui/asm/invalid-sym-operand.rs
@@ -1,3 +1,7 @@
+//@ needs-asm-support
+//@ ignore-nvptx64
+//@ ignore-spirv
+
 use std::arch::{asm, global_asm};
 
 // Sym operands must point to a function or static

--- a/tests/ui/asm/invalid-sym-operand.stderr
+++ b/tests/ui/asm/invalid-sym-operand.stderr
@@ -1,5 +1,5 @@
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:23:24
+  --> $DIR/invalid-sym-operand.rs:27:24
    |
 LL |         asm!("{}", sym x);
    |                        ^ is a local variable
@@ -7,7 +7,7 @@ LL |         asm!("{}", sym x);
    = help: `sym` operands must refer to either a function or a static
 
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:9:19
+  --> $DIR/invalid-sym-operand.rs:13:19
    |
 LL | global_asm!("{}", sym C);
    |                   ^^^^^ is an `i32`
@@ -15,7 +15,7 @@ LL | global_asm!("{}", sym C);
    = help: `sym` operands must refer to either a function or a static
 
 error: invalid `sym` operand
-  --> $DIR/invalid-sym-operand.rs:21:20
+  --> $DIR/invalid-sym-operand.rs:25:20
    |
 LL |         asm!("{}", sym C);
    |                    ^^^^^ is an `i32`


### PR DESCRIPTION
I think this'll fix it? at least this seems to work for the other tests that use the `asm!` macro. the failure was due to 

```
2024-08-02T18:22:20.9620865Z error[E0658]: inline assembly is not stable yet on this architecture
2024-08-02T18:22:20.9621812Z ##[error]  --> /checkout/tests/ui/asm/invalid-sym-operand.rs:8:1
2024-08-02T18:22:20.9622770Z    |
2024-08-02T18:22:20.9623048Z LL | global_asm!("{}", sym main);
2024-08-02T18:22:20.9623658Z    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-02T18:22:20.9624019Z    |
2024-08-02T18:22:20.9624628Z    = note: see issue #93335 <https://github.com/rust-lang/rust/issues/93335> for more information
2024-08-02T18:22:20.9625415Z    = help: add `#![feature(asm_experimental_arch)]` to the crate attributes to enable
2024-08-02T18:22:20.9626270Z    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
```